### PR TITLE
Fix string payload issue

### DIFF
--- a/src/services/Jwts.php
+++ b/src/services/Jwts.php
@@ -158,10 +158,7 @@ class Jwts extends Base
                 // Parse the payload to an object, if it's a valid json string.
                 if (is_string($decodedJwt->data)) {
                     $jsonPayload = json_decode($decodedJwt->data);
-                    if (!is_null($jsonPayload)) {
-                        return $jsonPayload;
-                    }
-                    return null;
+                    return $jsonPayload ? $jsonPayload : null;
                 }
                 return $decodedJwt->data;
             }

--- a/src/services/Jwts.php
+++ b/src/services/Jwts.php
@@ -161,6 +161,7 @@ class Jwts extends Base
                     if (!is_null($jsonPayload)) {
                         return $jsonPayload;
                     }
+                    return null;
                 }
                 return $decodedJwt->data;
             }

--- a/src/services/Jwts.php
+++ b/src/services/Jwts.php
@@ -155,6 +155,13 @@ class Jwts extends Base
 
             // Do we have any data?
             if (isset($decodedJwt->data) && !empty($decodedJwt->data)) {
+                // Parse the payload to an object, if it's a valid json string.
+                if (is_string($decodedJwt->data)) {
+                    $jsonPayload = json_decode($decodedJwt->data);
+                    if (!is_null($jsonPayload)) {
+                        return $jsonPayload;
+                    }
+                }
                 return $decodedJwt->data;
             }
 

--- a/src/services/Login.php
+++ b/src/services/Login.php
@@ -127,6 +127,14 @@ class Login extends Base
             $this->setError(JwtManager::$plugin->jwts->getError());
             return false;
         }
+        
+        // Parse the payload to an object, if it's a valid json string.
+        if (is_string($payload)) {
+            $payloadCheck = json_decode($payload);
+            if (!is_null($payloadCheck)) {
+                $payload = $payloadCheck;
+            }
+        }
 
         // Login user!
         if (!Craft::$app->getUser()->loginByUserId($payload->userId)) {

--- a/src/services/Login.php
+++ b/src/services/Login.php
@@ -127,14 +127,6 @@ class Login extends Base
             $this->setError(JwtManager::$plugin->jwts->getError());
             return false;
         }
-        
-        // Parse the payload to an object, if it's a valid json string.
-        if (is_string($payload)) {
-            $payloadCheck = json_decode($payload);
-            if (!is_null($payloadCheck)) {
-                $payload = $payloadCheck;
-            }
-        }
 
         // Login user!
         if (!Craft::$app->getUser()->loginByUserId($payload->userId)) {


### PR DESCRIPTION
When creating a new token via the `use-refresh` method, the payload of the new token is an unparsed json.